### PR TITLE
Add GHCR Docker publish workflow and single-container entrypoint

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,54 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ VOLUME /data
 WORKDIR /app/tools
 EXPOSE 8088
 
-# Default = the dashboard. The logger runs as a second service (see docker-compose.yml).
-CMD ["python", "server.py", "8088"]
+# Default = dashboard + logger together. Prefer separate services via docker-compose.yml
+# when you want independent restart/logs (web / logger override this CMD).
+CMD ["python", "entrypoint.py", "8088"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@
 # then:
 #   docker compose up -d                             # dashboard on http://localhost:8088
 #
+# Single-container (logger + web via entrypoint.py): omit the two services and run
+#   docker run --rm -p 8088:8088 -v ./data:/data j5-ev-dashboard
+# or override:  docker compose run --service-ports web python entrypoint.py 8088
+#
 # ./data holds creds.json, token.txt and carlinko.db (the only things that persist).
 
 services:
@@ -23,3 +27,4 @@ services:
     volumes:
       - ./data:/data
     restart: unless-stopped
+

--- a/tools/entrypoint.py
+++ b/tools/entrypoint.py
@@ -1,0 +1,67 @@
+"""Run dashboard + logger in one process tree (single-container / one-shot deploys).
+
+Starts logger.py --adaptive and server.py in parallel, forwards SIGTERM/SIGINT to
+both, and exits if either child dies so the supervisor (Docker/systemd) can restart.
+
+Usage:
+  python entrypoint.py [port]          # default port 8088
+  docker run ...                       # Dockerfile CMD points here
+"""
+import os
+import signal
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_kids = []
+
+
+def _stop(*_):
+    for p in _kids:
+        if p.poll() is None:
+            p.send_signal(signal.SIGTERM)
+    deadline = time.time() + 10
+    for p in _kids:
+        remaining = max(0, deadline - time.time())
+        try:
+            p.wait(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            p.kill()
+    # Prefer a non-zero exit if a child already failed.
+    codes = [p.returncode for p in _kids if p.returncode not in (None, 0, -signal.SIGTERM)]
+    sys.exit(codes[0] if codes else 0)
+
+
+def main():
+    port = "8088"
+    if len(sys.argv) > 1 and sys.argv[1].isdigit():
+        port = sys.argv[1]
+
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+
+    py = sys.executable
+    _kids.append(subprocess.Popen(
+        [py, "-u", os.path.join(HERE, "logger.py"), "--adaptive"],
+        cwd=HERE,
+    ))
+    _kids.append(subprocess.Popen(
+        [py, "-u", os.path.join(HERE, "server.py"), port],
+        cwd=HERE,
+    ))
+    print(f"entrypoint: logger + server on :{port}  (pid {[p.pid for p in _kids]})",
+          flush=True)
+
+    while True:
+        for p in _kids:
+            rc = p.poll()
+            if rc is not None:
+                print(f"entrypoint: child pid={p.pid} exited ({rc}); shutting down",
+                      flush=True)
+                _stop()
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that builds the Docker image on PRs and pushes to GHCR on `main` / version tags (with `workflow_dispatch`).
- Add `tools/entrypoint.py` so a single container can run logger + dashboard together; Dockerfile default CMD uses it.
- Document the single-container path in `docker-compose.yml` (existing two-service compose remains the preferred setup).

## Test plan
- [ ] Workflow runs on a PR (build only, no push)
- [ ] `docker build -t j5-ev-dashboard .` succeeds
- [ ] `docker run --rm -p 8088:8088 -v ./data:/data j5-ev-dashboard` serves the dashboard and starts the logger
- [ ] Existing `docker compose up -d` (web + logger services) still works unchanged