### PR TITLE
Add Home Assistant MQTT discovery and control bridge

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,54 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,8 @@ their own vehicle.
 
 1. Keep changes focused — one feature/fix per PR.
 2. The server is **stdlib-only** (`http.server`, `sqlite3`); please don't add web-framework
-   dependencies. The only runtime pip deps are `requests` + `websocket-client` (for the logger).
+   dependencies. Runtime pip deps live in [`requirements.txt`](requirements.txt)
+   (`requests`, `websocket-client`, `paho-mqtt` for the HA MQTT bridge).
 3. **Never** include `creds.json`, `token.txt`, tokens, API keys, your VIN or plate in a commit,
    screenshot, or log paste. Redact before posting.
 4. If you touch telemetry decoding, say which car/region you validated against.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.12-slim
 
 WORKDIR /app
-RUN pip install --no-cache-dir requests websocket-client
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY tools/ /app/tools/
 COPY web/  /app/web/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ VOLUME /data
 WORKDIR /app/tools
 EXPOSE 8088
 
-# Default = the dashboard. The logger runs as a second service (see docker-compose.yml).
-CMD ["python", "server.py", "8088"]
+# Default = dashboard + logger together. Prefer separate services via docker-compose.yml
+# when you want independent restart/logs (web / logger override this CMD).
+CMD ["python", "entrypoint.py", "8088"]

--- a/README.id.md
+++ b/README.id.md
@@ -98,7 +98,7 @@ Kalau ga setuju sama poin di atas, jangan dipakai.
   long-press tombolnya. **Cloud-only — belum bisa Bluetooth.** Lihat
   [docs/control-opcodes.md](docs/control-opcodes.md).
 - **Perawatan baterai, hitung mundur servis, tampilan ban, toggle privasi, dark mode, i18n EN/ID.**
-- **Home Assistant** — baca semua lewat REST sensor + notif batre-low / charge-selesai. Lihat [docs/HOMEASSISTANT.md](docs/HOMEASSISTANT.md).
+- **Home Assistant** — MQTT discovery atau REST sensor; event batre-low / charge-selesai. Lihat [docs/HOMEASSISTANT.md](docs/HOMEASSISTANT.md).
 
 Lihat [PRODUCT.md](PRODUCT.md) untuk alasan produk dan [DESIGN.md](DESIGN.md) untuk sistem visual.
 
@@ -170,7 +170,7 @@ pernah dikirim ke server manapun yang aku kontrol. Detail lengkap di **[SECURITY
 ## Setup
 
 ### Prasyarat
-- Python 3.10+, `pip install requests websocket-client`
+- Python 3.10+, `pip install -r requirements.txt`
 - Akun CarLinko yang ada mobilmu
 - (opsional) Google Maps API key untuk perencana trip / peta SPKLU
 
@@ -227,7 +227,7 @@ diakses dari mana saja tapi tetap tak terlihat oleh siapa pun. Gratis untuk pema
 
 ### Cara cepat — Python (manual)
 ```bash
-pip install requests websocket-client
+pip install -r requirements.txt
 cd tools
 python setup.py                # konfigurasi interaktif + login + auto-deteksi mobil
 python logger.py --adaptive    # rekam telemetri (cepat saat aktif, lambat saat parkir)
@@ -285,7 +285,7 @@ Set up the open-source project https://github.com/GodrezJr2/j5-ev-dashboard on t
 Clone it, then bring it up with Docker (docker compose up -d). It serves a login page on
 http://localhost:8088 — tell me the URL when it's running. I'll enter my CarLinko email and
 password there myself; do not ask me for them. If Docker isn't available, fall back to the
-Python quick-start in the README (pip install requests websocket-client, then run
+Python quick-start in the README (pip install -r requirements.txt, then run
 tools/server.py and tools/logger.py). If the host is reachable from the internet, remind me to
 set a dashboard password on the login page's Advanced section.
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you don't accept the above, don't use this.
   Only *stop charging* is confirmed; the rest are best-effort labels you can re-map by long-pressing
   a button. **Cloud only — no Bluetooth.** See [docs/control-opcodes.md](docs/control-opcodes.md).
 - **Battery care, service countdown, tyre view, privacy toggles, dark mode, EN/ID i18n.**
-- **Home Assistant** — read it all over a REST sensor and get battery-low / charge-done notifications. See [docs/HOMEASSISTANT.md](docs/HOMEASSISTANT.md). Prefer a native integration? [ha-carlinko](https://github.com/jebentancour/ha-carlinko) by [@jebentancour](https://github.com/jebentancour) (read-only, built on the same telemetry).
+- **Home Assistant** — MQTT discovery (sensors + lock/climate/covers/buttons) or a REST sensor; battery-low / charge-done events. See [docs/HOMEASSISTANT.md](docs/HOMEASSISTANT.md). Prefer a native integration? [ha-carlinko](https://github.com/jebentancour/ha-carlinko) by [@jebentancour](https://github.com/jebentancour) (read-only, built on the same telemetry).
 
 See [PRODUCT.md](PRODUCT.md) for the product rationale and [DESIGN.md](DESIGN.md) for the
 visual system.
@@ -168,7 +168,7 @@ never sent to any server I control. See **[SECURITY.md](SECURITY.md)** for the f
 ## Setup
 
 ### Prerequisites
-- Python 3.10+, `pip install requests websocket-client`
+- Python 3.10+, `pip install -r requirements.txt`
 - A CarLinko account with your car on it
 - (optional) a Google Maps API key for the trip planner / SPKLU map
 
@@ -228,7 +228,7 @@ personal use.
 
 ### Quick start — Python (manual)
 ```bash
-pip install requests websocket-client
+pip install -r requirements.txt
 cd tools
 python setup.py                # interactive config + login + auto-detect car
 python logger.py --adaptive    # record telemetry (fast when awake, slow when parked)
@@ -357,7 +357,7 @@ Set up the open-source project https://github.com/GodrezJr2/j5-ev-dashboard on t
 Clone it, then bring it up with Docker (docker compose up -d). It serves a login page on
 http://localhost:8088 — tell me the URL when it's running. I'll enter my CarLinko email and
 password there myself; do not ask me for them. If Docker isn't available, fall back to the
-Python quick-start in the README (pip install requests websocket-client, then run
+Python quick-start in the README (pip install -r requirements.txt, then run
 tools/server.py and tools/logger.py). If the host is reachable from the internet, remind me to
 set a dashboard password on the login page's Advanced section.
 ```

--- a/creds.example.json
+++ b/creds.example.json
@@ -32,5 +32,17 @@
   "resync_km_comment": "late cloud re-sync bursts (odo catches up after the car was dark): skip = accurate per-day totals (default, recommended) | count = add them to the day the car reconnected",
   "car_image": "OPTIONAL__setup.py_already_grabs_your_car's_own_render__set_only_to_override",
 
-  "gmaps_key": "OPTIONAL__google_maps_api_key_for_trip_planner_and_spklu_map"
+  "gmaps_key": "OPTIONAL__google_maps_api_key_for_trip_planner_and_spklu_map",
+
+  "mqtt": {
+    "_comment": "OPTIONAL Home Assistant MQTT bridge (also configurable in Settings). Needs paho-mqtt from requirements.txt. Opcode map: tools/control_opcodes.json",
+    "enabled": false,
+    "host": "homeassistant.local",
+    "port": 1883,
+    "username": "",
+    "password": "",
+    "tls": false,
+    "base_topic": "j5",
+    "discovery_prefix": "homeassistant"
+  }
 }

--- a/creds.example.json
+++ b/creds.example.json
@@ -35,7 +35,7 @@
   "gmaps_key": "OPTIONAL__google_maps_api_key_for_trip_planner_and_spklu_map",
 
   "mqtt": {
-    "_comment": "OPTIONAL Home Assistant MQTT bridge (also configurable in Settings). Needs paho-mqtt from requirements.txt. Opcode map: tools/control_opcodes.json",
+    "_comment": "OPTIONAL Home Assistant MQTT bridge (also configurable in Settings). Needs paho-mqtt from requirements.txt. Opcode map: tools/control_opcodes.json. Topics are {base_topic}/{VIN}/… so two cars can share the same base_topic.",
     "enabled": false,
     "host": "homeassistant.local",
     "port": 1883,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@
 # then:
 #   docker compose up -d                             # dashboard on http://localhost:8088
 #
+# Single-container (logger + web via entrypoint.py): omit the two services and run
+#   docker run --rm -p 8088:8088 -v ./data:/data j5-ev-dashboard
+# or override:  docker compose run --service-ports web python entrypoint.py 8088
+#
 # ./data holds creds.json, token.txt and carlinko.db (the only things that persist).
 
 services:
@@ -23,3 +27,4 @@ services:
     volumes:
       - ./data:/data
     restart: unless-stopped
+

--- a/docs/HOMEASSISTANT.md
+++ b/docs/HOMEASSISTANT.md
@@ -2,19 +2,70 @@
 
 > **Native integration exists:** [ha-carlinko](https://github.com/jebentancour/ha-carlinko) by
 > [@jebentancour](https://github.com/jebentancour) is a read-only Home Assistant integration built
-> on the same telemetry (no dashboard needed in the middle). The REST-sensor path below is the
-> zero-install alternative that reads this dashboard's own API.
-
-The dashboard already exposes everything as JSON at `GET /api/summary`, so Home Assistant can
-read it with a built-in **REST sensor** — no extra add-on, no code. You get entities for battery,
-range, charging, etc., and can fire automations (e.g. *battery low → notify my phone*).
+> on the same telemetry (no dashboard needed in the middle). The REST-sensor and MQTT paths below
+> are the zero-extra-component alternatives that use this dashboard.
 
 ## Before you start
-- Home Assistant must be able to reach the dashboard URL (same LAN, or both on Tailscale).
+- Home Assistant must be able to reach the dashboard URL (same LAN, or both on Tailscale) **or**
+  share an MQTT broker with the dashboard.
 - If you set a **dashboard password** (public hosting), `/api/summary` is locked, so a plain REST
-  sensor gets `401`. For Home Assistant, run the instance **un-gated on a private network /
+  sensor gets `401`. For Home Assistant REST, run the instance **un-gated on a private network /
   Tailscale** (recommended) so HA can read it directly. (A read-only API token for gated instances
   isn't built yet — open an issue if you want it.)
+- MQTT works fine with a gated dashboard: the bridge runs server-side and talks to the broker.
+
+## MQTT (recommended for push + controls)
+
+The dashboard can publish telemetry with **MQTT discovery** and accept named remote-control
+commands (lock, climate, covers, find, stop charging). Configure it in **Settings → MQTT**, or in
+`creds.json`:
+
+```json
+"mqtt": {
+  "enabled": true,
+  "host": "homeassistant.local",
+  "port": 1883,
+  "username": "",
+  "password": "",
+  "tls": false,
+  "base_topic": "j5",
+  "discovery_prefix": "homeassistant"
+}
+```
+
+Requires `paho-mqtt` (listed in `requirements.txt` — installed by `install.sh` / Docker).
+
+Once connected, Home Assistant should auto-create a device with sensors (battery, range, odometer,
+12V, charge power, consumption), binary sensors (charging, online), and — when your car supports
+them — lock, climate (on/off), window/sunroof/liftgate covers, and Find / Stop-charging buttons.
+
+### State
+| Entity | Source |
+| --- | --- |
+| Lock | telemetry `unlocked` (verified) |
+| Climate on/off | telemetry `ac_on` |
+| Windows / sunroof / liftgate | body bytes (E5-verified; treat as best-effort on other models) |
+| Sensors | same fields as `/api/summary` |
+
+Availability follows car freshness (~40 min): when the car is dark, entities go unavailable.
+
+### Commands
+Commands use **named actions**, not raw hex. Opcodes live in `tools/control_opcodes.json`
+(shipped with the repo; only **stop charging** `742701` is confirmed). Long-press a Control-tab
+button to remap — that updates the shared file so MQTT and the UI stay in sync.
+
+Events (non-retained): `{base_topic}/event/charge_complete`, `{base_topic}/event/battery_low`.
+
+### Topic sketch
+```
+{base}/sensor/battery
+{base}/lock/state          ← LOCKED / UNLOCKED
+{base}/control/lock/set    ← LOCK / UNLOCK
+{base}/control/climate/set ← off / cool
+{base}/control/windows/set ← OPEN / CLOSE / VENT
+{base}/control/result      ← last command ack JSON
+{base}/availability
+```
 
 ## REST sensors
 Add to `configuration.yaml` (change the host/port to your instance):
@@ -100,6 +151,9 @@ automation:
 Replace `YOURPHONE` with your Home Assistant companion-app device (the `notify.mobile_app_*`
 service it registers).
 
+With MQTT you can also trigger on `{base_topic}/event/charge_complete` /
+`{base_topic}/event/battery_low` for push instead of poll edge-detection.
+
 ## Fields you can map
 `/api/summary` also carries (handy for more sensors / templates):
 
@@ -110,13 +164,12 @@ service it registers).
 | `odometer` | total km |
 | `volt12` | 12 V battery voltage |
 | `online` | car reachable (bool) |
+| `unlocked` | lock state (bool: unlocked) |
+| `ac_on` | climate on (bool) |
+| `trunk_open` / `windows` / `sunroof_open` | body state |
 | `charging.active` | charging now (bool) |
 | `charging.rate_kw` | live charge power (kW) |
 | `energy.consumption` | car's avg kWh/100km |
 | `energy.today_kwh` | energy used today (kWh) |
 | `tyre_status` | `Normal` / `Check tyres` (indirect TPMS, no PSI) |
 | `insights.rp_per_km`, `insights.real_range` | running cost / real-world range |
-
-## MQTT (not packaged yet)
-A push-based MQTT publisher (HA auto-discovery, instant charge-done events) isn't built into this
-repo yet — the REST sensor above covers most needs. If you'd prefer MQTT, open an issue.

--- a/docs/HOMEASSISTANT.md
+++ b/docs/HOMEASSISTANT.md
@@ -35,6 +35,10 @@ commands (lock, climate, covers, find, stop charging). Configure it in **Setting
 
 Requires `paho-mqtt` (listed in `requirements.txt` — installed by `install.sh` / Docker).
 
+Topics are **per-vehicle** automatically: `{base_topic}/{VIN}/…` (falls back to plate, then
+CarLinko `vehicle_id`). Two dashboard instances can share the same `base_topic` and broker
+without colliding. `base_topic` is only a shared prefix (default `j5`).
+
 Once connected, Home Assistant should auto-create a device with sensors (battery, range, odometer,
 12V, charge power, consumption), binary sensors (charging, online), and — when your car supports
 them — lock, climate (on/off), window/sunroof/liftgate covers, and Find / Stop-charging buttons.
@@ -54,18 +58,20 @@ Commands use **named actions**, not raw hex. Opcodes live in `tools/control_opco
 (shipped with the repo; only **stop charging** `742701` is confirmed). Long-press a Control-tab
 button to remap — that updates the shared file so MQTT and the UI stay in sync.
 
-Events (non-retained): `{base_topic}/event/charge_complete`, `{base_topic}/event/battery_low`.
+Events (non-retained): `{base_topic}/{vin}/event/charge_complete`,
+`{base_topic}/{vin}/event/battery_low`.
 
 ### Topic sketch
 ```
-{base}/sensor/battery
-{base}/lock/state          ← LOCKED / UNLOCKED
-{base}/control/lock/set    ← LOCK / UNLOCK
-{base}/control/climate/set ← off / cool
-{base}/control/windows/set ← OPEN / CLOSE / VENT
-{base}/control/result      ← last command ack JSON
-{base}/availability
+{base}/{vin}/sensor/battery
+{base}/{vin}/lock/state          ← LOCKED / UNLOCKED
+{base}/{vin}/control/lock/set    ← LOCK / UNLOCK
+{base}/{vin}/control/climate/set ← off / cool
+{base}/{vin}/control/windows/set ← OPEN / CLOSE / VENT
+{base}/{vin}/control/result      ← last command ack JSON
+{base}/{vin}/availability
 ```
+(`{vin}` = VIN when known, else plate, else CarLinko vehicle_id.)
 
 ## REST sensors
 Add to `configuration.yaml` (change the host/port to your instance):
@@ -151,8 +157,8 @@ automation:
 Replace `YOURPHONE` with your Home Assistant companion-app device (the `notify.mobile_app_*`
 service it registers).
 
-With MQTT you can also trigger on `{base_topic}/event/charge_complete` /
-`{base_topic}/event/battery_low` for push instead of poll edge-detection.
+With MQTT you can also trigger on `{base_topic}/{vin}/event/charge_complete` /
+`{base_topic}/{vin}/event/battery_low` for push instead of poll edge-detection.
 
 ## Fields you can map
 `/api/summary` also carries (handy for more sensors / templates):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+websocket-client
+paho-mqtt

--- a/tools/auth.py
+++ b/tools/auth.py
@@ -26,7 +26,7 @@ TOKEN_FILE = os.path.join(_DATA, "token.txt")
 def cfg():
     """All instance-specific values live in creds.json (gitignored). See creds.example.json."""
     try:
-        return json.load(open(CREDS))
+        return json.load(open(CREDS, encoding="utf-8"))
     except Exception:
         return {}
 
@@ -44,7 +44,7 @@ def _require(val, name):
 
 def _region():
     try:
-        return json.load(open(CREDS)).get("region", "sea")
+        return json.load(open(CREDS, encoding="utf-8")).get("region", "sea")
     except Exception:
         return "sea"
 
@@ -75,7 +75,7 @@ def headers_for(params, token=None):
 
 def login():
     """Log in with stored creds, return the new token (and save it to token.txt)."""
-    c = json.load(open(CREDS))
+    c = json.load(open(CREDS, encoding="utf-8"))
     body = {
         "account": c["email"],
         "password": c["password"],

--- a/tools/control_opcodes.json
+++ b/tools/control_opcodes.json
@@ -1,0 +1,15 @@
+{
+  "lock": "741000",
+  "unlock": "741001",
+  "acOn": "742401",
+  "acOff": "742400",
+  "winOpen": "741501",
+  "winClose": "741500",
+  "winVent": "741502",
+  "roofOpen": "741A01",
+  "roofClose": "741A00",
+  "roofTilt": "741A02",
+  "liftOpen": "741201",
+  "find": "740100",
+  "chgStop": "742701"
+}

--- a/tools/entrypoint.py
+++ b/tools/entrypoint.py
@@ -1,0 +1,67 @@
+"""Run dashboard + logger in one process tree (single-container / one-shot deploys).
+
+Starts logger.py --adaptive and server.py in parallel, forwards SIGTERM/SIGINT to
+both, and exits if either child dies so the supervisor (Docker/systemd) can restart.
+
+Usage:
+  python entrypoint.py [port]          # default port 8088
+  docker run ...                       # Dockerfile CMD points here
+"""
+import os
+import signal
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_kids = []
+
+
+def _stop(*_):
+    for p in _kids:
+        if p.poll() is None:
+            p.send_signal(signal.SIGTERM)
+    deadline = time.time() + 10
+    for p in _kids:
+        remaining = max(0, deadline - time.time())
+        try:
+            p.wait(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            p.kill()
+    # Prefer a non-zero exit if a child already failed.
+    codes = [p.returncode for p in _kids if p.returncode not in (None, 0, -signal.SIGTERM)]
+    sys.exit(codes[0] if codes else 0)
+
+
+def main():
+    port = "8088"
+    if len(sys.argv) > 1 and sys.argv[1].isdigit():
+        port = sys.argv[1]
+
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+
+    py = sys.executable
+    _kids.append(subprocess.Popen(
+        [py, "-u", os.path.join(HERE, "logger.py"), "--adaptive"],
+        cwd=HERE,
+    ))
+    _kids.append(subprocess.Popen(
+        [py, "-u", os.path.join(HERE, "server.py"), port],
+        cwd=HERE,
+    ))
+    print(f"entrypoint: logger + server on :{port}  (pid {[p.pid for p in _kids]})",
+          flush=True)
+
+    while True:
+        for p in _kids:
+            rc = p.poll()
+            if rc is not None:
+                print(f"entrypoint: child pid={p.pid} exited ({rc}); shutting down",
+                      flush=True)
+                _stop()
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -51,7 +51,7 @@ fi
 say "Creating the virtualenv"
 [ -d "$VENV" ] || python3 -m venv "$VENV"
 "$VENV/bin/pip" install --quiet --upgrade pip
-"$VENV/bin/pip" install --quiet requests websocket-client
+"$VENV/bin/pip" install --quiet -r "$REPO/requirements.txt"
 echo "    $VENV"
 
 # ---------------------------------------------------------------- account setup

--- a/tools/logger.py
+++ b/tools/logger.py
@@ -22,7 +22,7 @@ _HERE = os.path.dirname(os.path.abspath(__file__))
 _DATA = os.environ.get("CARLINKO_DATA") or _HERE   # Docker data dir; else alongside the code
 def _cfg():
     try:
-        return json.load(open(os.path.join(_DATA, "creds.json")))
+        return json.load(open(os.path.join(_DATA, "creds.json"), encoding="utf-8"))
     except Exception:
         return {}
 _C = _cfg()

--- a/tools/mqtt_bridge.py
+++ b/tools/mqtt_bridge.py
@@ -33,7 +33,7 @@ DEFAULT_OPCODES = {
 }
 
 POLL_S = 2.5
-HEARTBEAT_S = 60.0
+HEARTBEAT_S = 30.0  # republish retained state at least this often; otherwise only on change
 ONLINE_AGE_MIN = 40.0
 BATTERY_LOW_PCT = 20
 
@@ -132,7 +132,7 @@ class MqttBridge:
         self._last_error = None
         self._last_publish_ts = None
         self._discovery_sent = False
-        self._last_payload = None
+        self._last_pubs = {}  # topic -> last payload string (skip unchanged publishes)
         self._last_pub_mono = 0.0
         self._prev_charge_state = None
         self._prev_battery = None
@@ -175,7 +175,8 @@ class MqttBridge:
             self._teardown_client()
             self._cfg = cfg
             self._discovery_sent = False
-            self._last_payload = None
+            self._last_pubs = {}
+            self._last_pub_mono = 0.0
         t = self._thread
         if t and t.is_alive() and t is not threading.current_thread():
             t.join(timeout=5)
@@ -301,6 +302,16 @@ class MqttBridge:
         if not isinstance(payload, str):
             payload = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
         c.publish(topic, payload, qos=0, retain=retain)
+
+    def _pub_if_changed(self, topic, payload, retain=True, force=False):
+        """Publish retained state only when the payload changed (or force=heartbeat)."""
+        if not isinstance(payload, str):
+            payload = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+        if not force and self._last_pubs.get(topic) == payload:
+            return False
+        self._pub(topic, payload, retain=retain)
+        self._last_pubs[topic] = payload
+        return True
 
     def _device_info(self):
         v = self.get_vehicle() or {}
@@ -457,10 +468,12 @@ class MqttBridge:
         if not self._discovery_sent:
             self._publish_discovery(caps)
 
+        base = self._cfg["base_topic"]
         latest = self._read_latest()
         if not latest:
-            base = self._cfg["base_topic"]
-            self._pub(f"{base}/binary_sensor/online", "OFF")
+            # Avoid spamming HA every poll when the DB has no frame yet.
+            self._pub_if_changed(f"{base}/binary_sensor/online", "OFF")
+            self._pub_if_changed(f"{base}/availability", "offline", retain=True)
             return
         ts, dec = latest
         age_min = (time.time() - ts) / 60.0
@@ -480,41 +493,39 @@ class MqttBridge:
         trunk_open = bool(dec.get("trunk_open"))
         consumption = dec.get("consumption") or ""
 
-        snap = {
-            "battery": battery, "range": dec.get("range_km"), "odo": dec.get("odometer"),
-            "volt12": dec.get("volt12"), "rate": rate, "consumption": consumption,
-            "charging": charging, "online": online, "unlocked": unlocked, "ac_on": ac_on,
-            "ac_temp": ac_temp if temp_ok else None, "windows": windows_open,
-            "sunroof": sunroof_open, "trunk": trunk_open, "cstate": cstate,
-        }
-        now = time.monotonic()
-        changed = snap != self._last_payload
-        due = (now - self._last_pub_mono) >= HEARTBEAT_S
-        if not changed and not due:
-            return
-
-        base = self._cfg["base_topic"]
         def n(v):
             return "" if v is None else str(v)
 
-        self._pub(f"{base}/sensor/battery", n(battery))
-        self._pub(f"{base}/sensor/range", n(dec.get("range_km")))
-        self._pub(f"{base}/sensor/odometer", n(dec.get("odometer")))
-        self._pub(f"{base}/sensor/volt12", n(dec.get("volt12")))
-        self._pub(f"{base}/sensor/charge_power", n(rate))
-        self._pub(f"{base}/sensor/consumption", n(consumption) if consumption else "")
-        self._pub(f"{base}/binary_sensor/charging", "ON" if charging else "OFF")
-        self._pub(f"{base}/binary_sensor/online", "ON" if online else "OFF")
-        self._pub(f"{base}/lock/state", "UNLOCKED" if unlocked else "LOCKED")
-        self._pub(f"{base}/climate/mode", "cool" if ac_on else "off")
-        self._pub(f"{base}/climate/action", "cooling" if ac_on else "off")
-        self._pub(f"{base}/climate/temperature", n(ac_temp) if temp_ok else "")
-        self._pub(f"{base}/cover/windows/state", "open" if windows_open else "closed")
-        self._pub(f"{base}/cover/sunroof/state", "open" if sunroof_open else "closed")
-        self._pub(f"{base}/cover/liftgate/state", "open" if trunk_open else "closed")
-        self._pub(f"{base}/availability", "online" if online else "offline", retain=True)
+        pubs = {
+            f"{base}/sensor/battery": n(battery),
+            f"{base}/sensor/range": n(dec.get("range_km")),
+            f"{base}/sensor/odometer": n(dec.get("odometer")),
+            f"{base}/sensor/volt12": n(dec.get("volt12")),
+            f"{base}/sensor/charge_power": n(rate),
+            f"{base}/sensor/consumption": n(consumption) if consumption else "",
+            f"{base}/binary_sensor/charging": "ON" if charging else "OFF",
+            f"{base}/binary_sensor/online": "ON" if online else "OFF",
+            f"{base}/lock/state": "UNLOCKED" if unlocked else "LOCKED",
+            f"{base}/climate/mode": "cool" if ac_on else "off",
+            f"{base}/climate/action": "cooling" if ac_on else "off",
+            f"{base}/climate/temperature": n(ac_temp) if temp_ok else "",
+            f"{base}/cover/windows/state": "open" if windows_open else "closed",
+            f"{base}/cover/sunroof/state": "open" if sunroof_open else "closed",
+            f"{base}/cover/liftgate/state": "open" if trunk_open else "closed",
+            f"{base}/availability": "online" if online else "offline",
+        }
 
-        # Edge events (not retained)
+        now = time.monotonic()
+        due = (now - self._last_pub_mono) >= HEARTBEAT_S
+        any_changed = any(self._last_pubs.get(t) != p for t, p in pubs.items())
+        if any_changed or due:
+            # On change: only the topics that differ. On heartbeat: refresh all retained state.
+            for topic, payload in pubs.items():
+                self._pub_if_changed(topic, payload, retain=True, force=due)
+            self._last_pub_mono = now
+            self._last_publish_ts = int(time.time())
+
+        # Edge events (non-retained) — real transitions only, never on heartbeat alone.
         if self._prev_charge_state == 1 and cstate == 2:
             self._pub(f"{base}/event/charge_complete",
                       {"battery": battery, "ts": int(time.time())}, retain=False)
@@ -528,9 +539,6 @@ class MqttBridge:
 
         self._prev_charge_state = cstate
         self._prev_battery = battery
-        self._last_payload = snap
-        self._last_pub_mono = now
-        self._last_publish_ts = int(time.time())
 
     def _fire_action(self, action_key):
         """Init 77 then fire mapped opcode. Returns result dict."""

--- a/tools/mqtt_bridge.py
+++ b/tools/mqtt_bridge.py
@@ -2,11 +2,16 @@
 
 Runs inside the dashboard server process. Soft-depends on paho-mqtt — if enabled in creds
 but the package is missing, logs a clear error and stays idle.
+
+Topics are namespaced per car out of the box:
+  {base_topic}/{VIN|plate|vehicle_id}/sensor/battery
+so two Docker instances on one broker do not collide when base_topic is shared.
 """
 from __future__ import annotations
 
 import json
 import os
+import re
 import sqlite3
 import threading
 import time
@@ -115,10 +120,20 @@ def _mqtt_cfg(raw=None):
         "username": (c.get("username") or "").strip(),
         "password": c.get("password") if c.get("password") is not None else "",
         "tls": bool(c.get("tls")),
+        # Prefix only — vehicle slug (VIN → plate → vehicle_id) is always appended.
         "base_topic": (c.get("base_topic") or "j5").strip().strip("/") or "j5",
         "discovery_prefix": (c.get("discovery_prefix") or "homeassistant").strip().strip("/")
                             or "homeassistant",
     }
+
+
+def _topic_slug(value):
+    """MQTT-safe segment from VIN / plate / id. Empty if missing or placeholder."""
+    s = str(value or "").strip()
+    if not s or s.lower() == "auto":
+        return ""
+    s = re.sub(r"[^A-Za-z0-9_-]+", "_", s).strip("_")
+    return s[:64]
 
 
 class MqttBridge:
@@ -153,7 +168,23 @@ class MqttBridge:
                 "last_error": self._last_error,
                 "last_publish_ts": self._last_publish_ts,
                 "has_paho": HAS_PAHO,
+                "topic_root": self._topic_root(),
+                "vehicle_slug": self._vehicle_slug(),
             }
+
+    def _vehicle_slug(self):
+        """Prefer VIN (stable, globally unique), then plate, then CarLinko vehicle_id."""
+        v = self.get_vehicle() or {}
+        for cand in (v.get("vin"), v.get("plate"), self.get_vehicle_id()):
+            s = _topic_slug(cand)
+            if s:
+                return s
+        return "car"
+
+    def _topic_root(self):
+        """Effective MQTT namespace: {base_topic}/{vehicle_slug}."""
+        base = (self._cfg.get("base_topic") or "j5").strip().strip("/") or "j5"
+        return f"{base}/{self._vehicle_slug()}"
 
     def start(self, mqtt_creds=None):
         self.reload(mqtt_creds)
@@ -204,8 +235,8 @@ class MqttBridge:
         if not c:
             return
         try:
-            base = self._cfg.get("base_topic") or "j5"
-            c.publish(f"{base}/availability", "offline", qos=0, retain=True)
+            root = self._topic_root()
+            c.publish(f"{root}/availability", "offline", qos=0, retain=True)
         except Exception:
             pass
         try:
@@ -246,21 +277,23 @@ class MqttBridge:
         self._teardown_client()
 
     def _make_client(self, cfg):
+        root = self._topic_root()
+        # Include vehicle slug so two cars on one broker don't share a client_id.
+        cid = f"carlinko-{root}".replace("/", "-")
         # paho v1 vs v2 callback API
         try:
             client = mqtt.Client(
                 mqtt.CallbackAPIVersion.VERSION1,
-                client_id=f"carlinko-{cfg['base_topic']}",
+                client_id=cid,
                 clean_session=True,
             )
         except Exception:
-            client = mqtt.Client(client_id=f"carlinko-{cfg['base_topic']}", clean_session=True)
+            client = mqtt.Client(client_id=cid, clean_session=True)
         if cfg["username"]:
             client.username_pw_set(cfg["username"], cfg["password"] or None)
         if cfg["tls"]:
             client.tls_set()
-        base = cfg["base_topic"]
-        client.will_set(f"{base}/availability", "offline", qos=0, retain=True)
+        client.will_set(f"{root}/availability", "offline", qos=0, retain=True)
         client.on_connect = self._on_connect
         client.on_disconnect = self._on_disconnect
         client.on_message = self._on_message
@@ -274,12 +307,13 @@ class MqttBridge:
             print("mqtt_bridge:", self._last_error, flush=True)
             return
         self._last_error = None
-        base = self._cfg["base_topic"]
-        # Subscribe all command topics under base/control/+/set and nested climate/covers.
-        client.subscribe(f"{base}/control/#")
-        client.publish(f"{base}/availability", "online", qos=0, retain=True)
+        root = self._topic_root()
+        # Subscribe all command topics under root/control/# (lock, climate, covers, …).
+        client.subscribe(f"{root}/control/#")
+        client.publish(f"{root}/availability", "online", qos=0, retain=True)
         self._discovery_sent = False
-        print("mqtt_bridge: connected to", self._cfg["host"], flush=True)
+        print("mqtt_bridge: connected to", self._cfg["host"],
+              "topics under", root, flush=True)
 
     def _on_disconnect(self, client, userdata, rc, *args):
         self._connected = False
@@ -328,7 +362,7 @@ class MqttBridge:
     def _publish_discovery(self, caps):
         cfg = self._cfg
         pref = cfg["discovery_prefix"]
-        base = cfg["base_topic"]
+        base = self._topic_root()
         avail = {"topic": f"{base}/availability"}
         device = self._device_info()
         uniq = device["identifiers"][0]
@@ -468,7 +502,7 @@ class MqttBridge:
         if not self._discovery_sent:
             self._publish_discovery(caps)
 
-        base = self._cfg["base_topic"]
+        base = self._topic_root()
         latest = self._read_latest()
         if not latest:
             # Avoid spamming HA every poll when the DB has no frame yet.
@@ -557,11 +591,11 @@ class MqttBridge:
                 "ts": int(time.time())}
 
     def _ack(self, result):
-        base = self._cfg["base_topic"]
+        base = self._topic_root()
         self._pub(f"{base}/control/result", result, retain=False)
 
     def _handle_command(self, topic, payload):
-        base = self._cfg["base_topic"]
+        base = self._topic_root()
         prefix = f"{base}/control/"
         if not topic.startswith(prefix) or not topic.endswith("/set"):
             return

--- a/tools/mqtt_bridge.py
+++ b/tools/mqtt_bridge.py
@@ -1,0 +1,650 @@
+"""Home Assistant MQTT bridge: discovery, telemetry publish, named remote-control commands.
+
+Runs inside the dashboard server process. Soft-depends on paho-mqtt — if enabled in creds
+but the package is missing, logs a clear error and stays idle.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+import traceback
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_DATA = os.environ.get("CARLINKO_DATA") or HERE
+
+# Fallback if tools/control_opcodes.json is missing/corrupt. The shipped file is the source of truth.
+DEFAULT_OPCODES = {
+    "lock": "741000",
+    "unlock": "741001",
+    "acOn": "742401",
+    "acOff": "742400",
+    "winOpen": "741501",
+    "winClose": "741500",
+    "winVent": "741502",
+    "roofOpen": "741A01",
+    "roofClose": "741A00",
+    "roofTilt": "741A02",
+    "liftOpen": "741201",
+    "find": "740100",
+    "chgStop": "742701",
+}
+
+POLL_S = 2.5
+HEARTBEAT_S = 60.0
+ONLINE_AGE_MIN = 40.0
+BATTERY_LOW_PCT = 20
+
+try:
+    import paho.mqtt.client as mqtt
+    HAS_PAHO = True
+except ImportError:
+    mqtt = None
+    HAS_PAHO = False
+
+
+def opcodes_path():
+    # Static protocol map lives next to the code (tools/), not in the mutable data volume.
+    return os.path.join(HERE, "control_opcodes.json")
+
+
+def load_opcodes():
+    """Read tools/control_opcodes.json; fall back to DEFAULT_OPCODES if missing/corrupt."""
+    out = dict(DEFAULT_OPCODES)
+    path = opcodes_path()
+    if not os.path.isfile(path):
+        return out
+    try:
+        raw = json.load(open(path, encoding="utf-8"))
+    except Exception:
+        return out
+    if not isinstance(raw, dict):
+        return out
+    for k, v in raw.items():
+        if k.startswith("_"):
+            continue
+        if k not in DEFAULT_OPCODES:
+            continue
+        s = str(v or "").strip()
+        if s and all(ch in "0123456789abcdefABCDEF" for ch in s) and len(s) <= 16:
+            out[k] = s
+    return out
+
+
+def save_opcodes(mapping):
+    """Merge validated remaps into tools/control_opcodes.json. Returns the effective map."""
+    path = opcodes_path()
+    existing = dict(DEFAULT_OPCODES)
+    if os.path.isfile(path):
+        try:
+            raw = json.load(open(path, encoding="utf-8"))
+            if isinstance(raw, dict):
+                for k, v in raw.items():
+                    if str(k).startswith("_") or k not in DEFAULT_OPCODES:
+                        continue
+                    s = str(v or "").strip()
+                    if s:
+                        existing[k] = s
+        except Exception:
+            pass
+    clean = dict(existing)
+    for k, v in (mapping or {}).items():
+        if k.startswith("_") or k not in DEFAULT_OPCODES:
+            continue
+        s = str(v or "").strip()
+        if not s:
+            clean[k] = DEFAULT_OPCODES[k]
+            continue
+        if not all(ch in "0123456789abcdefABCDEF" for ch in s) or len(s) > 16:
+            raise ValueError(f"invalid opcode for {k}")
+        clean[k] = s
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(clean, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    return load_opcodes()
+
+
+def _mqtt_cfg(raw=None):
+    c = raw if isinstance(raw, dict) else {}
+    return {
+        "enabled": bool(c.get("enabled")),
+        "host": (c.get("host") or "").strip(),
+        "port": int(c.get("port") or 1883),
+        "username": (c.get("username") or "").strip(),
+        "password": c.get("password") if c.get("password") is not None else "",
+        "tls": bool(c.get("tls")),
+        "base_topic": (c.get("base_topic") or "j5").strip().strip("/") or "j5",
+        "discovery_prefix": (c.get("discovery_prefix") or "homeassistant").strip().strip("/")
+                            or "homeassistant",
+    }
+
+
+class MqttBridge:
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._cfg = _mqtt_cfg()
+        self._client = None
+        self._thread = None
+        self._stop = threading.Event()
+        self._connected = False
+        self._last_error = None
+        self._last_publish_ts = None
+        self._discovery_sent = False
+        self._last_payload = None
+        self._last_pub_mono = 0.0
+        self._prev_charge_state = None
+        self._prev_battery = None
+        self._battery_low_latched = False
+        # Injected by server.py after import (avoids circular imports at module load).
+        self.get_db_path = lambda: None
+        self.decode = None
+        self.control_caps = lambda: {}
+        self.send_control = None
+        self.get_vehicle = lambda: {}
+        self.get_vehicle_id = lambda: ""
+
+    def status(self):
+        with self._lock:
+            return {
+                "enabled": self._cfg["enabled"],
+                "connected": self._connected,
+                "last_error": self._last_error,
+                "last_publish_ts": self._last_publish_ts,
+                "has_paho": HAS_PAHO,
+            }
+
+    def start(self, mqtt_creds=None):
+        self.reload(mqtt_creds)
+
+    def stop(self):
+        self._stop.set()
+        with self._lock:
+            self._teardown_client()
+        t = self._thread
+        if t and t.is_alive() and t is not threading.current_thread():
+            t.join(timeout=5)
+        self._thread = None
+
+    def reload(self, mqtt_creds=None):
+        """Apply new config; restart client/loop if needed."""
+        cfg = _mqtt_cfg(mqtt_creds)
+        self._stop.set()
+        with self._lock:
+            self._teardown_client()
+            self._cfg = cfg
+            self._discovery_sent = False
+            self._last_payload = None
+        t = self._thread
+        if t and t.is_alive() and t is not threading.current_thread():
+            t.join(timeout=5)
+        self._stop = threading.Event()
+        self._thread = None
+        if not cfg["enabled"]:
+            self._connected = False
+            self._last_error = None
+            return
+        if not HAS_PAHO:
+            self._last_error = "paho-mqtt not installed (pip install paho-mqtt)"
+            print("mqtt_bridge:", self._last_error, flush=True)
+            return
+        if not cfg["host"]:
+            self._last_error = "mqtt.host is empty"
+            print("mqtt_bridge:", self._last_error, flush=True)
+            return
+        self._thread = threading.Thread(target=self._run, name="mqtt-bridge", daemon=True)
+        self._thread.start()
+
+    def _teardown_client(self):
+        c = self._client
+        self._client = None
+        self._connected = False
+        if not c:
+            return
+        try:
+            base = self._cfg.get("base_topic") or "j5"
+            c.publish(f"{base}/availability", "offline", qos=0, retain=True)
+        except Exception:
+            pass
+        try:
+            c.loop_stop()
+        except Exception:
+            pass
+        try:
+            c.disconnect()
+        except Exception:
+            pass
+
+    def _run(self):
+        cfg = self._cfg
+        try:
+            client = self._make_client(cfg)
+        except Exception as e:
+            self._last_error = str(e)[:200]
+            print("mqtt_bridge: connect setup failed:", self._last_error, flush=True)
+            return
+        with self._lock:
+            self._client = client
+        try:
+            client.connect(cfg["host"], cfg["port"], keepalive=60)
+            client.loop_start()
+        except Exception as e:
+            self._last_error = str(e)[:200]
+            print("mqtt_bridge: connect failed:", self._last_error, flush=True)
+            self._teardown_client()
+            return
+
+        while not self._stop.wait(POLL_S):
+            try:
+                self._tick()
+            except Exception as e:
+                self._last_error = str(e)[:200]
+                print("mqtt_bridge: tick error:", self._last_error, flush=True)
+                traceback.print_exc()
+        self._teardown_client()
+
+    def _make_client(self, cfg):
+        # paho v1 vs v2 callback API
+        try:
+            client = mqtt.Client(
+                mqtt.CallbackAPIVersion.VERSION1,
+                client_id=f"carlinko-{cfg['base_topic']}",
+                clean_session=True,
+            )
+        except Exception:
+            client = mqtt.Client(client_id=f"carlinko-{cfg['base_topic']}", clean_session=True)
+        if cfg["username"]:
+            client.username_pw_set(cfg["username"], cfg["password"] or None)
+        if cfg["tls"]:
+            client.tls_set()
+        base = cfg["base_topic"]
+        client.will_set(f"{base}/availability", "offline", qos=0, retain=True)
+        client.on_connect = self._on_connect
+        client.on_disconnect = self._on_disconnect
+        client.on_message = self._on_message
+        return client
+
+    def _on_connect(self, client, userdata, flags, rc, *args):
+        ok = (rc == 0)
+        self._connected = ok
+        if not ok:
+            self._last_error = f"MQTT connect rc={rc}"
+            print("mqtt_bridge:", self._last_error, flush=True)
+            return
+        self._last_error = None
+        base = self._cfg["base_topic"]
+        # Subscribe all command topics under base/control/+/set and nested climate/covers.
+        client.subscribe(f"{base}/control/#")
+        client.publish(f"{base}/availability", "online", qos=0, retain=True)
+        self._discovery_sent = False
+        print("mqtt_bridge: connected to", self._cfg["host"], flush=True)
+
+    def _on_disconnect(self, client, userdata, rc, *args):
+        self._connected = False
+        if rc != 0:
+            self._last_error = f"MQTT disconnected rc={rc}"
+
+    def _on_message(self, client, userdata, msg):
+        try:
+            topic = msg.topic or ""
+            payload = (msg.payload or b"").decode("utf-8", "replace").strip()
+            self._handle_command(topic, payload)
+        except Exception as e:
+            self._last_error = str(e)[:200]
+            print("mqtt_bridge: command error:", self._last_error, flush=True)
+
+    def _pub(self, topic, payload, retain=True):
+        c = self._client
+        if not c or not self._connected:
+            return
+        if not isinstance(payload, str):
+            payload = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+        c.publish(topic, payload, qos=0, retain=retain)
+
+    def _device_info(self):
+        v = self.get_vehicle() or {}
+        vid = str(self.get_vehicle_id() or v.get("plate") or "car")
+        name = v.get("model") or v.get("plate") or "CarLinko EV"
+        return {
+            "identifiers": [f"carlinko_{vid}"],
+            "name": name,
+            "manufacturer": "CarLinko",
+            "model": v.get("model") or "EV",
+            "suggested_area": "Garage",
+        }
+
+    def _publish_discovery(self, caps):
+        cfg = self._cfg
+        pref = cfg["discovery_prefix"]
+        base = cfg["base_topic"]
+        avail = {"topic": f"{base}/availability"}
+        device = self._device_info()
+        uniq = device["identifiers"][0]
+
+        def disc(component, object_id, body):
+            body = dict(body)
+            body["availability"] = [avail]
+            body["device"] = device
+            body.setdefault("unique_id", f"{uniq}_{object_id}")
+            body.setdefault("object_id", object_id)
+            self._pub(f"{pref}/{component}/{uniq}/{object_id}/config", body, retain=True)
+
+        # Sensors
+        disc("sensor", "battery", {
+            "name": "Battery", "state_topic": f"{base}/sensor/battery",
+            "unit_of_measurement": "%", "device_class": "battery", "state_class": "measurement",
+        })
+        disc("sensor", "range", {
+            "name": "Range", "state_topic": f"{base}/sensor/range",
+            "unit_of_measurement": "km", "icon": "mdi:map-marker-distance",
+            "state_class": "measurement",
+        })
+        disc("sensor", "odometer", {
+            "name": "Odometer", "state_topic": f"{base}/sensor/odometer",
+            "unit_of_measurement": "km", "icon": "mdi:counter",
+            "state_class": "total_increasing",
+        })
+        disc("sensor", "volt12", {
+            "name": "12V Battery", "state_topic": f"{base}/sensor/volt12",
+            "unit_of_measurement": "V", "device_class": "voltage", "state_class": "measurement",
+        })
+        disc("sensor", "charge_power", {
+            "name": "Charge Power", "state_topic": f"{base}/sensor/charge_power",
+            "unit_of_measurement": "kW", "device_class": "power", "state_class": "measurement",
+        })
+        disc("sensor", "consumption", {
+            "name": "Consumption", "state_topic": f"{base}/sensor/consumption",
+            "unit_of_measurement": "kWh/100km", "icon": "mdi:lightning-bolt",
+            "state_class": "measurement",
+        })
+        disc("binary_sensor", "charging", {
+            "name": "Charging", "state_topic": f"{base}/binary_sensor/charging",
+            "payload_on": "ON", "payload_off": "OFF", "device_class": "battery_charging",
+        })
+        disc("binary_sensor", "online", {
+            "name": "Online", "state_topic": f"{base}/binary_sensor/online",
+            "payload_on": "ON", "payload_off": "OFF", "device_class": "connectivity",
+        })
+
+        caps = caps or {}
+        if caps.get("lock"):
+            disc("lock", "lock", {
+                "name": "Lock",
+                "state_topic": f"{base}/lock/state",
+                "command_topic": f"{base}/control/lock/set",
+                "payload_lock": "LOCK", "payload_unlock": "UNLOCK",
+                "state_locked": "LOCKED", "state_unlocked": "UNLOCKED",
+            })
+        ac = caps.get("ac") or {}
+        if ac.get("switch"):
+            disc("climate", "climate", {
+                "name": "Climate",
+                "mode_command_topic": f"{base}/control/climate/set",
+                "mode_state_topic": f"{base}/climate/mode",
+                "modes": ["off", "cool"],
+                "current_temperature_topic": f"{base}/climate/temperature",
+                "temperature_unit": "C",
+                "action_topic": f"{base}/climate/action",
+            })
+        win = caps.get("windows") or {}
+        if win.get("open") or win.get("close") or win.get("vent"):
+            disc("cover", "windows", {
+                "name": "Windows",
+                "state_topic": f"{base}/cover/windows/state",
+                "command_topic": f"{base}/control/windows/set",
+                "payload_open": "OPEN", "payload_close": "CLOSE", "payload_stop": "VENT",
+                "state_open": "open", "state_closed": "closed",
+                "device_class": "awning",
+            })
+        roof = caps.get("sunroof") or {}
+        if roof.get("open") or roof.get("tilt"):
+            disc("cover", "sunroof", {
+                "name": "Sunroof",
+                "state_topic": f"{base}/cover/sunroof/state",
+                "command_topic": f"{base}/control/sunroof/set",
+                "payload_open": "OPEN", "payload_close": "CLOSE", "payload_stop": "TILT",
+                "state_open": "open", "state_closed": "closed",
+                "device_class": "window",
+            })
+        if caps.get("liftgate") or caps.get("trunk"):
+            disc("cover", "liftgate", {
+                "name": "Liftgate",
+                "state_topic": f"{base}/cover/liftgate/state",
+                "command_topic": f"{base}/control/liftgate/set",
+                "payload_open": "OPEN", "payload_close": "CLOSE",
+                "state_open": "open", "state_closed": "closed",
+                "device_class": "garage",
+            })
+        if caps.get("find"):
+            disc("button", "find", {
+                "name": "Find car",
+                "command_topic": f"{base}/control/find/set",
+                "payload_press": "PRESS",
+            })
+        if caps.get("charging"):
+            disc("button", "charge_stop", {
+                "name": "Stop charging",
+                "command_topic": f"{base}/control/charge_stop/set",
+                "payload_press": "PRESS",
+            })
+        self._discovery_sent = True
+
+    def _read_latest(self):
+        db = self.get_db_path()
+        if not db or not os.path.exists(db) or not self.decode:
+            return None
+        conn = sqlite3.connect(db)
+        try:
+            row = conn.execute(
+                "SELECT ts, raw FROM telemetry WHERE online=1 AND raw IS NOT NULL "
+                "ORDER BY ts DESC LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+        if not row:
+            return None
+        ts, raw = row
+        return ts, self.decode(raw)
+
+    def _tick(self):
+        if not self._connected:
+            return
+        try:
+            caps = self.control_caps() or {}
+        except Exception:
+            caps = {}
+        if not self._discovery_sent:
+            self._publish_discovery(caps)
+
+        latest = self._read_latest()
+        if not latest:
+            base = self._cfg["base_topic"]
+            self._pub(f"{base}/binary_sensor/online", "OFF")
+            return
+        ts, dec = latest
+        age_min = (time.time() - ts) / 60.0
+        online = age_min < ONLINE_AGE_MIN
+        battery = dec.get("battery")
+        cstate = dec.get("charge_state")
+        charging = cstate == 1
+        rate = dec.get("charge_power") if charging else 0
+        if rate is None:
+            rate = 0
+        unlocked = bool(dec.get("unlocked"))
+        ac_on = bool(dec.get("ac_on"))
+        ac_temp = dec.get("ac_temp_c")
+        temp_ok = isinstance(ac_temp, int) and 16 <= ac_temp <= 30
+        windows_open = bool(dec.get("windows"))
+        sunroof_open = bool(dec.get("sunroof_open"))
+        trunk_open = bool(dec.get("trunk_open"))
+        consumption = dec.get("consumption") or ""
+
+        snap = {
+            "battery": battery, "range": dec.get("range_km"), "odo": dec.get("odometer"),
+            "volt12": dec.get("volt12"), "rate": rate, "consumption": consumption,
+            "charging": charging, "online": online, "unlocked": unlocked, "ac_on": ac_on,
+            "ac_temp": ac_temp if temp_ok else None, "windows": windows_open,
+            "sunroof": sunroof_open, "trunk": trunk_open, "cstate": cstate,
+        }
+        now = time.monotonic()
+        changed = snap != self._last_payload
+        due = (now - self._last_pub_mono) >= HEARTBEAT_S
+        if not changed and not due:
+            return
+
+        base = self._cfg["base_topic"]
+        def n(v):
+            return "" if v is None else str(v)
+
+        self._pub(f"{base}/sensor/battery", n(battery))
+        self._pub(f"{base}/sensor/range", n(dec.get("range_km")))
+        self._pub(f"{base}/sensor/odometer", n(dec.get("odometer")))
+        self._pub(f"{base}/sensor/volt12", n(dec.get("volt12")))
+        self._pub(f"{base}/sensor/charge_power", n(rate))
+        self._pub(f"{base}/sensor/consumption", n(consumption) if consumption else "")
+        self._pub(f"{base}/binary_sensor/charging", "ON" if charging else "OFF")
+        self._pub(f"{base}/binary_sensor/online", "ON" if online else "OFF")
+        self._pub(f"{base}/lock/state", "UNLOCKED" if unlocked else "LOCKED")
+        self._pub(f"{base}/climate/mode", "cool" if ac_on else "off")
+        self._pub(f"{base}/climate/action", "cooling" if ac_on else "off")
+        self._pub(f"{base}/climate/temperature", n(ac_temp) if temp_ok else "")
+        self._pub(f"{base}/cover/windows/state", "open" if windows_open else "closed")
+        self._pub(f"{base}/cover/sunroof/state", "open" if sunroof_open else "closed")
+        self._pub(f"{base}/cover/liftgate/state", "open" if trunk_open else "closed")
+        self._pub(f"{base}/availability", "online" if online else "offline", retain=True)
+
+        # Edge events (not retained)
+        if self._prev_charge_state == 1 and cstate == 2:
+            self._pub(f"{base}/event/charge_complete",
+                      {"battery": battery, "ts": int(time.time())}, retain=False)
+        if battery is not None:
+            if battery < BATTERY_LOW_PCT and not self._battery_low_latched:
+                self._pub(f"{base}/event/battery_low",
+                          {"battery": battery, "ts": int(time.time())}, retain=False)
+                self._battery_low_latched = True
+            elif battery >= BATTERY_LOW_PCT + 5:
+                self._battery_low_latched = False
+
+        self._prev_charge_state = cstate
+        self._prev_battery = battery
+        self._last_payload = snap
+        self._last_pub_mono = now
+        self._last_publish_ts = int(time.time())
+
+    def _fire_action(self, action_key):
+        """Init 77 then fire mapped opcode. Returns result dict."""
+        if not self.send_control:
+            return {"ok": False, "error": "send_control not wired"}
+        ops = load_opcodes()
+        code = ops.get(action_key)
+        if not code:
+            return {"ok": False, "error": f"no opcode for {action_key}"}
+        init = self.send_control("77", 20)
+        time.sleep(0.6)
+        d = self.send_control(code, 20)
+        ok = str(d.get("code")) == "0000"
+        return {"ok": ok, "action": action_key, "opcode": code,
+                "code": d.get("code"), "msg": d.get("msg"), "init": init.get("code"),
+                "ts": int(time.time())}
+
+    def _ack(self, result):
+        base = self._cfg["base_topic"]
+        self._pub(f"{base}/control/result", result, retain=False)
+
+    def _handle_command(self, topic, payload):
+        base = self._cfg["base_topic"]
+        prefix = f"{base}/control/"
+        if not topic.startswith(prefix) or not topic.endswith("/set"):
+            return
+        mid = topic[len(prefix):-len("/set")]  # e.g. lock, climate, windows, charge_stop
+        pl = payload.upper()
+        action = None
+
+        if mid == "lock":
+            if pl == "LOCK":
+                action = "lock"
+            elif pl == "UNLOCK":
+                action = "unlock"
+        elif mid == "climate":
+            # HA may send mode string or JSON {"mode":"cool"|"off",...}
+            mode = pl
+            if payload.startswith("{"):
+                try:
+                    mode = str(json.loads(payload).get("mode") or "").upper()
+                except Exception:
+                    mode = pl
+            if mode in ("OFF", "0"):
+                action = "acOff"
+            elif mode in ("COOL", "HEAT", "AUTO", "ON"):
+                action = "acOn"
+        elif mid == "windows":
+            if pl == "OPEN":
+                action = "winOpen"
+            elif pl == "CLOSE":
+                action = "winClose"
+            elif pl in ("VENT", "STOP"):
+                action = "winVent"
+        elif mid == "sunroof":
+            if pl == "OPEN":
+                action = "roofOpen"
+            elif pl == "CLOSE":
+                action = "roofClose"
+            elif pl in ("TILT", "STOP"):
+                action = "roofTilt"
+        elif mid == "liftgate":
+            if pl == "OPEN":
+                action = "liftOpen"
+            # CLOSE not mapped distinctly in CTRL_ACTIONS; ignore
+        elif mid == "find":
+            if pl in ("PRESS", "ON", "1"):
+                action = "find"
+        elif mid == "charge_stop":
+            if pl in ("PRESS", "ON", "1"):
+                action = "chgStop"
+
+        if not action:
+            self._ack({"ok": False, "error": "unknown command", "topic": topic, "payload": payload})
+            return
+
+        # Capability gate
+        try:
+            caps = self.control_caps() or {}
+        except Exception:
+            caps = {}
+        if not self._action_allowed(action, caps):
+            self._ack({"ok": False, "error": "not supported by this car", "action": action})
+            return
+
+        result = self._fire_action(action)
+        self._ack(result)
+
+    @staticmethod
+    def _action_allowed(action, caps):
+        if action in ("lock", "unlock"):
+            return bool(caps.get("lock"))
+        if action in ("acOn", "acOff"):
+            return bool((caps.get("ac") or {}).get("switch"))
+        if action == "winOpen":
+            return bool((caps.get("windows") or {}).get("open"))
+        if action == "winClose":
+            return bool((caps.get("windows") or {}).get("close"))
+        if action == "winVent":
+            return bool((caps.get("windows") or {}).get("vent"))
+        if action == "roofOpen":
+            return bool((caps.get("sunroof") or {}).get("open"))
+        if action == "roofClose":
+            return bool((caps.get("sunroof") or {}).get("open"))
+        if action == "roofTilt":
+            return bool((caps.get("sunroof") or {}).get("tilt"))
+        if action == "liftOpen":
+            return bool(caps.get("liftgate") or caps.get("trunk"))
+        if action == "find":
+            return bool(caps.get("find"))
+        if action == "chgStop":
+            return bool(caps.get("charging"))
+        return False
+
+
+# Singleton used by server.py
+bridge = MqttBridge()

--- a/tools/server.py
+++ b/tools/server.py
@@ -1,4 +1,4 @@
-"""CarLinko dashboard server (stdlib only).
+"""CarLinko dashboard server (stdlib + optional paho-mqtt for Home Assistant).
 Serves the mobile PWA in ./web and a JSON API computed from carlinko.db.
 Run: python server.py [port]   (default 8088, binds 0.0.0.0 so Tailscale can reach it)
 """
@@ -796,6 +796,8 @@ def demo_summary():
         "vehicle": {"plate": "B 1234 DEMO", "model": "Jaecoo J5 EV", "vin": "DEMOVIN00000J5EV"},
         "online": True, "battery": 72, "range_km": 318, "odometer": 8421, "volt12": 13.6,
         "unlocked": False, "speed": None, "moving": False, "avg_speed": 41,
+        "ac_on": False, "ac_temp_c": 22, "doors": 0, "trunk_open": False,
+        "windows": 0, "sunroof_open": False,
         "updated": time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(now - 180)), "age_min": 3.0,
         "battery_kwh": cap, "battery_kwh_source": "known", "wltp_kwh_100": 14.8,
         "chemistry_known": True, "powertrain": "bev", "fuel": None,
@@ -839,6 +841,8 @@ def summary():
         return demo_summary()
     out = {"vehicle": VEHICLE, "online": False, "battery": None, "range_km": None,
            "odometer": None, "volt12": None, "unlocked": None, "speed": None,
+           "ac_on": None, "ac_temp_c": None, "doors": None, "trunk_open": None,
+           "windows": None, "sunroof_open": None,
            "moving": False, "avg_speed": None, "insights": {}, "health": {}, "drain": None,
            "volt12_min7d": None, "volt12_status": None,
            "updated": None, "age_min": None,
@@ -877,6 +881,15 @@ def summary():
     out.update(battery=dec.get("battery"), range_km=dec.get("range_km"),
                odometer=dec.get("odometer"), volt12=dec.get("volt12"),
                unlocked=dec.get("unlocked"), speed=None, updated=dt)
+    # Body / climate bytes (decoded in decode(); lock verified on J5+E5, A/C+doors+windows
+    # live-verified on E5 #5 — surfaced for REST + MQTT so HA can use real state).
+    out["ac_on"] = bool(dec.get("ac_on"))
+    out["doors"] = dec.get("doors")
+    out["trunk_open"] = bool(dec.get("trunk_open")) if dec.get("trunk_open") is not None else None
+    out["windows"] = dec.get("windows")
+    out["sunroof_open"] = bool(dec.get("sunroof_open")) if dec.get("sunroof_open") is not None else None
+    ac_temp = dec.get("ac_temp_c")
+    out["ac_temp_c"] = ac_temp if (isinstance(ac_temp, int) and 16 <= ac_temp <= 30) else None
     out["age_min"] = round((time.time() - ts) / 60, 1)
     out["online"] = out["age_min"] is not None and out["age_min"] < 40
     # Fuel side of a PHEV. Decided over the whole window, not the latest frame, so a car sitting at
@@ -1423,10 +1436,47 @@ class H(BaseHTTPRequestHandler):
             if not self._authed():
                 self._send(401, b'{"error":"auth"}', "application/json"); return
             try:
-                self._send(200, json.dumps({"caps": control_caps(), "known": KNOWN_OPCODES}).encode(),
+                import mqtt_bridge as MB
+                self._send(200, json.dumps({"caps": control_caps(), "known": KNOWN_OPCODES,
+                                            "opcodes": MB.load_opcodes()}).encode(),
                            "application/json")
             except Exception as e:
                 self._send(200, json.dumps({"error": str(e)[:180]}).encode(), "application/json")
+            return
+        if path == "/api/mqtt":                        # MQTT bridge config + status (password redacted)
+            if not self._authed():
+                self._send(401, b'{"error":"auth"}', "application/json"); return
+            try:
+                import mqtt_bridge as MB
+                m = (_creds().get("mqtt") or {}) if isinstance(_creds().get("mqtt"), dict) else {}
+                cfg = {
+                    "enabled": bool(m.get("enabled")),
+                    "host": m.get("host") or "",
+                    "port": int(m.get("port") or 1883),
+                    "username": m.get("username") or "",
+                    "password_set": bool(m.get("password")),
+                    "tls": bool(m.get("tls")),
+                    "base_topic": m.get("base_topic") or "j5",
+                    "discovery_prefix": m.get("discovery_prefix") or "homeassistant",
+                }
+                self._send(200, json.dumps({"ok": True, "config": cfg,
+                                            "status": MB.bridge.status()}).encode(),
+                           "application/json")
+            except Exception as e:
+                self._send(200, json.dumps({"ok": False, "error": str(e)[:180]}).encode(),
+                           "application/json")
+            return
+        if path == "/api/opcodes":
+            if not self._authed():
+                self._send(401, b'{"error":"auth"}', "application/json"); return
+            try:
+                import mqtt_bridge as MB
+                self._send(200, json.dumps({"ok": True, "opcodes": MB.load_opcodes(),
+                                            "defaults": MB.DEFAULT_OPCODES}).encode(),
+                           "application/json")
+            except Exception as e:
+                self._send(200, json.dumps({"ok": False, "error": str(e)[:180]}).encode(),
+                           "application/json")
             return
         if path == "/car-photo":     # cached proxy for CarLinko's own render of this exact car.
             try:                     # Behind the gate: the render gives away model + colour.
@@ -1639,7 +1689,97 @@ class H(BaseHTTPRequestHandler):
                 self._send(200, json.dumps({"ok": False, "error": str(e)[:120]}).encode(),
                            "application/json")
             return
+        if path == "/api/mqtt":
+            if not self._authed():
+                self._send(401, b'{"ok":false,"error":"auth"}', "application/json"); return
+            try:
+                n = int(self.headers.get("Content-Length") or 0)
+                body = json.loads(self.rfile.read(n).decode() or "{}")
+                cpath = os.path.join(_DATA, "creds.json")
+                try:
+                    c = json.load(open(cpath, encoding="utf-8"))
+                except Exception:
+                    c = {}
+                cur = c.get("mqtt") if isinstance(c.get("mqtt"), dict) else {}
+                m = dict(cur)
+                if "enabled" in body:
+                    m["enabled"] = bool(body.get("enabled"))
+                if "host" in body:
+                    m["host"] = str(body.get("host") or "").strip()
+                if "port" in body:
+                    try:
+                        m["port"] = int(body.get("port") or 1883)
+                    except Exception:
+                        m["port"] = 1883
+                if "username" in body:
+                    m["username"] = str(body.get("username") or "").strip()
+                if "password" in body and body.get("password") is not None and body.get("password") != "":
+                    m["password"] = str(body.get("password"))
+                # omit / null / "" password → keep existing
+                if "tls" in body:
+                    m["tls"] = bool(body.get("tls"))
+                if "base_topic" in body:
+                    m["base_topic"] = str(body.get("base_topic") or "j5").strip() or "j5"
+                if "discovery_prefix" in body:
+                    m["discovery_prefix"] = (str(body.get("discovery_prefix") or "homeassistant").strip()
+                                             or "homeassistant")
+                c["mqtt"] = m
+                json.dump(c, open(cpath, "w", encoding="utf-8"), indent=2, ensure_ascii=False)
+                try: os.chmod(cpath, 0o600)
+                except Exception: pass
+                import mqtt_bridge as MB
+                MB.bridge.reload(m)
+                cfg = {
+                    "enabled": bool(m.get("enabled")),
+                    "host": m.get("host") or "",
+                    "port": int(m.get("port") or 1883),
+                    "username": m.get("username") or "",
+                    "password_set": bool(m.get("password")),
+                    "tls": bool(m.get("tls")),
+                    "base_topic": m.get("base_topic") or "j5",
+                    "discovery_prefix": m.get("discovery_prefix") or "homeassistant",
+                }
+                self._send(200, json.dumps({"ok": True, "config": cfg,
+                                            "status": MB.bridge.status()}).encode(),
+                           "application/json")
+            except Exception as e:
+                self._send(200, json.dumps({"ok": False, "error": str(e)[:180]}).encode(),
+                           "application/json")
+            return
+        if path == "/api/opcodes":
+            if not self._authed():
+                self._send(401, b'{"ok":false,"error":"auth"}', "application/json"); return
+            try:
+                n = int(self.headers.get("Content-Length") or 0)
+                body = json.loads(self.rfile.read(n).decode() or "{}")
+                import mqtt_bridge as MB
+                mapping = body.get("opcodes") if isinstance(body.get("opcodes"), dict) else body
+                ops = MB.save_opcodes(mapping)
+                self._send(200, json.dumps({"ok": True, "opcodes": ops}).encode(),
+                           "application/json")
+            except Exception as e:
+                self._send(200, json.dumps({"ok": False, "error": str(e)[:180]}).encode(),
+                           "application/json")
+            return
         self._send(404, b"not found", "text/plain")
+
+def _start_mqtt_bridge():
+    """Wire callbacks and start the HA MQTT bridge when enabled in creds.json."""
+    if DEMO:
+        return
+    try:
+        import mqtt_bridge as MB
+        MB._DATA = _DATA
+        MB.bridge.get_db_path = lambda: DB
+        MB.bridge.decode = decode
+        MB.bridge.control_caps = control_caps
+        MB.bridge.send_control = send_control
+        MB.bridge.get_vehicle = lambda: dict(VEHICLE)
+        MB.bridge.get_vehicle_id = lambda: str((_creds().get("vehicle_id") or ""))
+        m = _creds().get("mqtt") if isinstance(_creds().get("mqtt"), dict) else {}
+        MB.bridge.start(m)
+    except Exception as e:
+        print("mqtt_bridge: failed to start:", repr(e), flush=True)
 
 def main():
     ports = [a for a in sys.argv[1:] if a.isdigit()]       # ignore flags like --demo
@@ -1649,6 +1789,7 @@ def main():
     else:
         _ensure_db()                                       # so a brand-new install serves without crashing
         print(f"CarLinko dashboard on http://0.0.0.0:{port}  (db={os.path.abspath(DB)})")
+        _start_mqtt_bridge()
     ThreadingHTTPServer(("0.0.0.0", port), H).serve_forever()
 
 if __name__ == "__main__":

--- a/tools/server.py
+++ b/tools/server.py
@@ -37,7 +37,7 @@ WEB  = os.path.join(HERE, "..", "web")
 
 def _creds():
     try:
-        return json.load(open(os.path.join(_DATA, "creds.json")))
+        return json.load(open(os.path.join(_DATA, "creds.json"), encoding="utf-8"))
     except Exception:
         return {}
 
@@ -46,7 +46,7 @@ def _resync_skip():
     a day. Default "skip": keep them out of daily totals (accurate per-day numbers). "count" = old
     behaviour: add them to the day the car reconnected. Toggled from the dashboard Settings tab."""
     try:
-        return str(json.load(open(os.path.join(_DATA, "creds.json"))).get("resync_km", "skip")).lower() != "count"
+        return str(json.load(open(os.path.join(_DATA, "creds.json"), encoding="utf-8")).get("resync_km", "skip")).lower() != "count"
     except Exception:
         return True
 
@@ -103,7 +103,7 @@ def web_login(email, password, region="sea", gmaps_key=None, dashboard_password=
     if gmaps_key and gmaps_key.strip():
         c["gmaps_key"] = gmaps_key.strip()
     cpath = os.path.join(_DATA, "creds.json")
-    json.dump(c, open(cpath, "w"), indent=2)
+    json.dump(c, open(cpath, "w", encoding="utf-8"), indent=2, ensure_ascii=False)
     try: os.chmod(cpath, 0o600)
     except Exception: pass
     import auth, requests
@@ -121,7 +121,7 @@ def web_login(email, password, region="sea", gmaps_key=None, dashboard_password=
             c["vehicle"]["img"] = img                     # web login now captures the render too
             try: os.remove(_CAR_PHOTO)                    # (previously only CLI setup.py did)
             except Exception: pass                        # bust the old car's cached photo
-        json.dump(c, open(cpath, "w"), indent=2)
+        json.dump(c, open(cpath, "w", encoding="utf-8"), indent=2, ensure_ascii=False)
         try: os.chmod(cpath, 0o600)
         except Exception: pass
         VEHICLE.update(c["vehicle"])                        # reflect immediately, no restart
@@ -236,7 +236,7 @@ def _gated():
 
 def _save_creds(c):
     cpath = os.path.join(_DATA, "creds.json")
-    json.dump(c, open(cpath, "w"), indent=2)
+    json.dump(c, open(cpath, "w", encoding="utf-8"), indent=2, ensure_ascii=False)
     try: os.chmod(cpath, 0o600)
     except Exception: pass
 
@@ -1097,7 +1097,7 @@ def _ev_info(pl):
     return {"dc_kw": dc_kw, "conns": blurb, "avail": avail, "updated": updated}
 
 def _gkey():
-    try: return json.load(open(os.path.join(_DATA, "creds.json"))).get("gmaps_key")
+    try: return json.load(open(os.path.join(_DATA, "creds.json"), encoding="utf-8")).get("gmaps_key")
     except Exception: return None
 
 def _g_post(url, body, fieldmask, timeout=9):
@@ -1604,7 +1604,7 @@ class H(BaseHTTPRequestHandler):
                                "application/json"); return
                 c = _creds(); c.setdefault("vehicle", {})["img"] = img
                 cpath = os.path.join(_DATA, "creds.json")
-                json.dump(c, open(cpath, "w"), indent=2)
+                json.dump(c, open(cpath, "w", encoding="utf-8"), indent=2, ensure_ascii=False)
                 try: os.chmod(cpath, 0o600)
                 except Exception: pass
                 try: os.remove(_CAR_PHOTO)              # force a fresh cache pull
@@ -1626,11 +1626,11 @@ class H(BaseHTTPRequestHandler):
                                "application/json"); return
                 cpath = os.path.join(_DATA, "creds.json")
                 try:
-                    c = json.load(open(cpath))
+                    c = json.load(open(cpath, encoding="utf-8"))
                 except Exception:
                     c = {}
                 c["resync_km"] = body["resync_km"]
-                json.dump(c, open(cpath, "w"), indent=2)
+                json.dump(c, open(cpath, "w", encoding="utf-8"), indent=2, ensure_ascii=False)
                 try: os.chmod(cpath, 0o600)
                 except Exception: pass
                 self._send(200, json.dumps({"ok": True, "resync_km": c["resync_km"]}).encode(),

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -162,7 +162,7 @@ def main():
     c = {}
     if os.path.exists(CREDS):
         try:
-            c = json.load(open(CREDS))
+            c = json.load(open(CREDS, encoding="utf-8"))
             print(f"Editing existing {CREDS} (press Enter to keep a value).\n")
         except Exception:
             pass
@@ -179,7 +179,7 @@ def main():
                          c.get("gmaps_key"), secret=True, optional=True)
 
     # write what we have first, so a later failure still saves progress
-    json.dump(c, open(CREDS, "w"), indent=2)
+    json.dump(c, open(CREDS, "w", encoding="utf-8"), indent=2, ensure_ascii=False)
     try:
         os.chmod(CREDS, 0o600)
     except Exception:
@@ -229,7 +229,7 @@ def main():
             pass
         learn_from_config(c, v)
         ask_battery(c, c["vehicle"]["model"])
-        json.dump(c, open(CREDS, "w"), indent=2)
+        json.dump(c, open(CREDS, "w", encoding="utf-8"), indent=2, ensure_ascii=False)
         try:
             os.chmod(CREDS, 0o600)
         except Exception:

--- a/web/index.html
+++ b/web/index.html
@@ -398,6 +398,14 @@
     text-align:right;background:var(--surface);color:var(--ink);-moz-appearance:textfield}
   .fuelin input::-webkit-outer-spin-button,.fuelin input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
   .fuelin #fuelKml{width:44px}
+  .mqttgrid{display:flex;flex-direction:column;gap:0;width:100%;padding-top:6px}
+  .mqttgrid .setrow{padding:10px 0}
+  .mqttin{font:inherit;font-size:13px;font-weight:600;color:var(--ink);background:var(--surface);
+    border:1px solid var(--line);border-radius:10px;padding:8px 12px;max-width:220px;text-align:right}
+  .mqttin.wide{max-width:100%;text-align:left;width:100%}
+  #mqttStatus{font-size:12px;color:var(--muted);margin-top:4px}
+  #mqttStatus.ok{color:var(--accent)}
+  #mqttStatus.err{color:var(--bad)}
 
   /* trip planner */
   .tpform{display:flex;flex-direction:column;gap:10px}
@@ -640,6 +648,27 @@
     <div class="hint" id="resyncHint">When the car is dark (no signal), missed km sync in one burst. Accurate (recommended) skips bursts that can't be dated to a day; Count all adds them to the day the car reconnects.</div>
     <div class="setrow"><span class="sl">Car photo</span>
       <button class="setbtn" id="photoBtn">Update</button></div>
+    <div class="head2" style="margin-top:22px"><div class="over">MQTT</div></div>
+    <div class="hint" id="mqttHint">Publish telemetry to Home Assistant via MQTT discovery, and accept lock / climate / cover / button commands. Needs <code>paho-mqtt</code> on the server.</div>
+    <div class="mqttgrid">
+      <div class="setrow"><span class="sl">Enabled</span>
+        <span class="seg" id="mqttEnSeg"><button data-v="0">Off</button><button data-v="1">On</button></span></div>
+      <div class="setrow"><span class="sl">Host</span>
+        <input class="mqttin wide" id="mqttHost" type="text" placeholder="homeassistant.local" autocomplete="off"></div>
+      <div class="setrow"><span class="sl">Port</span>
+        <input class="mqttin" id="mqttPort" type="number" inputmode="numeric" placeholder="1883"></div>
+      <div class="setrow"><span class="sl">TLS</span>
+        <span class="seg" id="mqttTlsSeg"><button data-v="0">Off</button><button data-v="1">On</button></span></div>
+      <div class="setrow"><span class="sl">Username</span>
+        <input class="mqttin wide" id="mqttUser" type="text" autocomplete="off"></div>
+      <div class="setrow"><span class="sl">Password</span>
+        <input class="mqttin wide" id="mqttPass" type="password" placeholder="unchanged if blank" autocomplete="new-password"></div>
+      <div class="setrow"><span class="sl">Base topic</span>
+        <input class="mqttin" id="mqttBase" type="text" placeholder="j5"></div>
+      <div class="setrow"><span class="sl"></span>
+        <button class="setbtn" id="mqttSave">Save</button></div>
+      <div id="mqttStatus">—</div>
+    </div>
   </section>
 
   <section class="tripplan">
@@ -844,6 +873,13 @@ const MAP_ID={
   "Settings":"Pengaturan","Theme":"Tema","Light":"Terang","Dark":"Gelap","Language":"Bahasa",
   "Km sync":"Sinkron km","Count all":"Hitung semua",
   "Car photo":"Foto mobil","Update":"Perbarui",
+  "MQTT":"MQTT","Enabled":"Aktif","Host":"Host","Port":"Port","TLS":"TLS",
+  "Username":"Pengguna","Password":"Kata sandi","Base topic":"Topik dasar","Save":"Simpan",
+  "MQTT off":"MQTT mati","Connected":"Terhubung","Connecting…":"Menghubungkan…",
+  "unchanged if blank":"kosongkan = tidak diubah","password":"kata sandi",
+  "Off":"Mati","On":"Nyala",
+  "Publish telemetry to Home Assistant via MQTT discovery, and accept lock / climate / cover / button commands. Needs paho-mqtt on the server.":
+  "Kirim telemetri ke Home Assistant lewat MQTT discovery, dan terima perintah kunci / iklim / cover / tombol. Butuh paho-mqtt di server.",
   "Charged":"Diisi",
   "Tap a day for its km, energy and charging.":"Ketuk hari untuk km, energi, dan pengisiannya.",
   "When the car is dark (no signal), missed km sync in one burst. Accurate (recommended) skips bursts that can't be dated to a day; Count all adds them to the day the car reconnects.":
@@ -920,6 +956,62 @@ $('photoBtn').addEventListener('click',async e=>{ const b=$('photoBtn'); b.disab
     }
   }catch(ex){}
   b.disabled=false; b.textContent=old; });
+
+// ---- MQTT settings (Home Assistant bridge) ----
+function syncMqttSeg(en, tls){
+  document.querySelectorAll('#mqttEnSeg button').forEach(b=>b.classList.toggle('on', b.dataset.v===(en?'1':'0')));
+  document.querySelectorAll('#mqttTlsSeg button').forEach(b=>b.classList.toggle('on', b.dataset.v===(tls?'1':'0')));
+}
+function mqttStatusLine(st, cfg){
+  const el=$('mqttStatus'); if(!el) return;
+  el.className='';
+  if(!cfg || !cfg.enabled){ el.textContent=T('MQTT off'); return; }
+  if(st && st.last_error){ el.className='err'; el.textContent=st.last_error; return; }
+  if(st && st.connected){ el.className='ok';
+    const t=st.last_publish_ts?(' · pub '+new Date(st.last_publish_ts*1000).toLocaleTimeString()):'';
+    el.textContent=T('Connected')+t; return; }
+  el.textContent=T('Connecting…');
+}
+async function loadMqtt(){
+  try{
+    const d=await (await fetch('api/mqtt',{cache:'no-store'})).json();
+    if(!d || !d.ok) return;
+    const c=d.config||{};
+    syncMqttSeg(!!c.enabled, !!c.tls);
+    if($('mqttHost')) $('mqttHost').value=c.host||'';
+    if($('mqttPort')) $('mqttPort').value=c.port||1883;
+    if($('mqttUser')) $('mqttUser').value=c.username||'';
+    if($('mqttPass')){ $('mqttPass').value=''; $('mqttPass').placeholder=c.password_set?T('unchanged if blank'):T('password'); }
+    if($('mqttBase')) $('mqttBase').value=c.base_topic||'j5';
+    mqttStatusLine(d.status, c);
+  }catch(e){}
+}
+$('mqttEnSeg').addEventListener('click',e=>{ const b=e.target.closest('button'); if(!b)return;
+  document.querySelectorAll('#mqttEnSeg button').forEach(x=>x.classList.toggle('on',x===b)); });
+$('mqttTlsSeg').addEventListener('click',e=>{ const b=e.target.closest('button'); if(!b)return;
+  document.querySelectorAll('#mqttTlsSeg button').forEach(x=>x.classList.toggle('on',x===b)); });
+$('mqttSave').addEventListener('click',async()=>{
+  const b=$('mqttSave'); b.disabled=true; const old=b.textContent; b.textContent='…';
+  const body={
+    enabled: !!document.querySelector('#mqttEnSeg button.on[data-v="1"]'),
+    host: ($('mqttHost').value||'').trim(),
+    port: parseInt($('mqttPort').value,10)||1883,
+    tls: !!document.querySelector('#mqttTlsSeg button.on[data-v="1"]'),
+    username: ($('mqttUser').value||'').trim(),
+    base_topic: ($('mqttBase').value||'j5').trim()||'j5',
+  };
+  const pw=$('mqttPass').value; if(pw) body.password=pw;
+  try{
+    const d=await (await fetch('api/mqtt',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify(body)})).json();
+    if(!d.ok) throw new Error(d.error||'failed');
+    buzz(8); $('mqttPass').value='';
+    if(d.config&&d.config.password_set) $('mqttPass').placeholder=T('unchanged if blank');
+    mqttStatusLine(d.status, d.config);
+    setTimeout(loadMqtt, 1500);
+  }catch(ex){ const el=$('mqttStatus'); if(el){ el.className='err'; el.textContent=String(ex.message||ex); } }
+  b.disabled=false; b.textContent=old;
+});
 
 // ---- dist view: 7-day bars <-> monthly calendar (lazy /api/history, cached per month) ----
 let distView='bars'; try{ distView=localStorage.getItem('distView')||'bars'; }catch(e){}
@@ -1524,9 +1616,22 @@ const CTRL_ACTIONS=[
 // These are the "on/open" variants (visible action) — tap each at the car to identify, then report.
 // The car may need init (2301/24/77) first. UNKNOWN mapping — watch the car; any may actuate.
 const CTRL_CANDIDATES=["740100","740200","740300","740400","740500","740600","740700","740800","740A00","740E00","740F01","741001","741201","741501","741601","741701","741901","741A01","741B01","741C01","741E01","741F01","742001","742301","742401","742501","742701"];
-let CTRL_CAPS=null, CTRL_KNOWN=[];
-function ctrlMap(){ try{return JSON.parse(localStorage.getItem('ctrlMap')||'{}');}catch(e){return {};} }
-function ctrlSetOp(k,op){ const m=ctrlMap(); if(op) m[k]=op.trim(); else delete m[k]; localStorage.setItem('ctrlMap',JSON.stringify(m)); }
+let CTRL_CAPS=null, CTRL_KNOWN=[], CTRL_OPCODES={};
+function ctrlMap(){ // server map wins; localStorage is a cache for offline / older servers
+  if(CTRL_OPCODES && Object.keys(CTRL_OPCODES).length) return CTRL_OPCODES;
+  try{return JSON.parse(localStorage.getItem('ctrlMap')||'{}');}catch(e){return {};} }
+async function ctrlSetOp(k,op){
+  const m=Object.assign({}, ctrlMap());
+  if(op) m[k]=op.trim(); else delete m[k];
+  CTRL_OPCODES=m;
+  try{ localStorage.setItem('ctrlMap',JSON.stringify(m)); }catch(e){}
+  try{
+    const r=await fetch('api/opcodes',{method:'POST',headers:{'content-type':'application/json'},
+      body:JSON.stringify({opcodes:{[k]:op?op.trim():''}})});
+    const d=await r.json();
+    if(d && d.ok && d.opcodes) CTRL_OPCODES=d.opcodes;
+  }catch(e){}
+}
 function ctrlLog(msg){ const el=$('ctrlLog'); if(!el)return; const t=new Date().toLocaleTimeString();
   el.insertAdjacentHTML('afterbegin','<div>'+t+' &mdash; '+msg+'</div>'); }
 async function fireOpcode(op,to){
@@ -1553,13 +1658,13 @@ function renderControls(){
     b.innerHTML='<span>'+a.lbl+'</span><small>'+(op?op:'tap to set')+'</small>';
     b.addEventListener('click',async()=>{
       const code=ctrlMap()[a.k]||a.op;
-      if(!code){ const nv=(prompt('Opcode (hex) for "'+a.lbl+'"','')||'').trim(); if(!nv) return; ctrlSetOp(a.k,nv); renderControls(); return; }
+      if(!code){ const nv=(prompt('Opcode (hex) for "'+a.lbl+'"','')||'').trim(); if(!nv) return; await ctrlSetOp(a.k,nv); renderControls(); return; }
       if(a.confirm && !confirm(a.lbl+' — send now?')) return;
       b.classList.add('busy');
       try{ await fireOpcode('77',20); await new Promise(r=>setTimeout(r,600)); await fireOpcode(code,20); }
       finally{ b.classList.remove('busy'); }
     });
-    let lp; b.addEventListener('pointerdown',()=>{ lp=setTimeout(()=>{ const nv=prompt('Opcode for "'+a.lbl+'" (mismatch? fix it here)',ctrlMap()[a.k]||a.op||''); if(nv!==null){ ctrlSetOp(a.k,nv.trim()); renderControls(); } },600); });
+    let lp; b.addEventListener('pointerdown',()=>{ lp=setTimeout(async()=>{ const nv=prompt('Opcode for "'+a.lbl+'" (mismatch? fix it here)',ctrlMap()[a.k]||a.op||''); if(nv!==null){ await ctrlSetOp(a.k,nv.trim()); renderControls(); } },600); });
     ['pointerup','pointerleave','pointercancel'].forEach(ev=>b.addEventListener(ev,()=>clearTimeout(lp)));
     grid.appendChild(b);
   });
@@ -1575,7 +1680,9 @@ function renderControls(){
 }
 async function loadControls(){
   try{ const r=await fetch('api/controls'); const d=await r.json();
-    if(d && d.caps){ CTRL_CAPS=d.caps; CTRL_KNOWN=d.known||[]; renderControls(); } }catch(e){}
+    if(d && d.caps){ CTRL_CAPS=d.caps; CTRL_KNOWN=d.known||[];
+      if(d.opcodes){ CTRL_OPCODES=d.opcodes; try{ localStorage.setItem('ctrlMap',JSON.stringify(d.opcodes)); }catch(e){} }
+      renderControls(); } }catch(e){}
 }
 const SHEETS={battery:bBattery,rpkm:bRpkm,forecast:bForecast,range:bRange,health:bHealth,eff:bEff,charge:bCharge,tyres:bTyres,odo:bOdo,volt:bVolt,speed:bSpeed,life:bLife,care:bCare,spec:bSpec};
 function bind(el,key){ if(!el)return; el.classList.add('tappable'); el.addEventListener('click',()=>sheet(SHEETS[key]())); }
@@ -1880,12 +1987,14 @@ bindStatic();                                          // make cards/stats tappa
 if($('ctrlFire')) $('ctrlFire').addEventListener('click',()=>fireOpcode($('ctrlOp').value,$('ctrlTo').value));
 if($('ctrlDiscToggle')) $('ctrlDiscToggle').addEventListener('click',()=>{ const d=$('ctrlDisc'); d.style.display=d.style.display==='none'?'':'none'; });
 loadControls();                                        // fetch what this car supports + opcodes to test
+loadMqtt();                                            // MQTT bridge settings + status
 showTab('home');                                       // start on Home
 load();                                                // read the stream-fresh DB on open
 setInterval(()=>{ if(!document.hidden) load(); }, 5000);  // the box streams the car over one socket;
                                                        // just re-read its always-fresh DB every 5s ->
                                                        // live screen, zero extra load on CarLinko
-document.addEventListener('visibilitychange',()=>{ if(!document.hidden) load(); });
+setInterval(()=>{ if(!document.hidden) loadMqtt(); }, 15000);  // refresh MQTT connection status
+document.addEventListener('visibilitychange',()=>{ if(!document.hidden){ load(); loadMqtt(); } });
 </script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -649,7 +649,7 @@
     <div class="setrow"><span class="sl">Car photo</span>
       <button class="setbtn" id="photoBtn">Update</button></div>
     <div class="head2" style="margin-top:22px"><div class="over">MQTT</div></div>
-    <div class="hint" id="mqttHint">Publish telemetry to Home Assistant via MQTT discovery, and accept lock / climate / cover / button commands. Needs <code>paho-mqtt</code> on the server.</div>
+    <div class="hint" id="mqttHint">Publish telemetry to Home Assistant via MQTT discovery, and accept lock / climate / cover / button commands. Topics are <code>{prefix}/{VIN}/…</code> so two cars can share one broker. Needs <code>paho-mqtt</code> on the server.</div>
     <div class="mqttgrid">
       <div class="setrow"><span class="sl">Enabled</span>
         <span class="seg" id="mqttEnSeg"><button data-v="0">Off</button><button data-v="1">On</button></span></div>
@@ -663,7 +663,7 @@
         <input class="mqttin wide" id="mqttUser" type="text" autocomplete="off"></div>
       <div class="setrow"><span class="sl">Password</span>
         <input class="mqttin wide" id="mqttPass" type="password" placeholder="unchanged if blank" autocomplete="new-password"></div>
-      <div class="setrow"><span class="sl">Base topic</span>
+      <div class="setrow"><span class="sl">Topic prefix</span>
         <input class="mqttin" id="mqttBase" type="text" placeholder="j5"></div>
       <div class="setrow"><span class="sl"></span>
         <button class="setbtn" id="mqttSave">Save</button></div>
@@ -874,12 +874,12 @@ const MAP_ID={
   "Km sync":"Sinkron km","Count all":"Hitung semua",
   "Car photo":"Foto mobil","Update":"Perbarui",
   "MQTT":"MQTT","Enabled":"Aktif","Host":"Host","Port":"Port","TLS":"TLS",
-  "Username":"Pengguna","Password":"Kata sandi","Base topic":"Topik dasar","Save":"Simpan",
+  "Username":"Pengguna","Password":"Kata sandi","Topic prefix":"Prefix topik","Save":"Simpan",
   "MQTT off":"MQTT mati","Connected":"Terhubung","Connecting…":"Menghubungkan…",
   "unchanged if blank":"kosongkan = tidak diubah","password":"kata sandi",
   "Off":"Mati","On":"Nyala",
-  "Publish telemetry to Home Assistant via MQTT discovery, and accept lock / climate / cover / button commands. Needs paho-mqtt on the server.":
-  "Kirim telemetri ke Home Assistant lewat MQTT discovery, dan terima perintah kunci / iklim / cover / tombol. Butuh paho-mqtt di server.",
+  "Publish telemetry to Home Assistant via MQTT discovery, and accept lock / climate / cover / button commands. Topics are {prefix}/{VIN}/… so two cars can share one broker. Needs paho-mqtt on the server.":
+  "Kirim telemetri ke Home Assistant lewat MQTT discovery, dan terima perintah kunci / iklim / cover / tombol. Topik berbentuk {prefix}/{VIN}/… supaya dua mobil bisa pakai broker yang sama. Butuh paho-mqtt di server.",
   "Charged":"Diisi",
   "Tap a day for its km, energy and charging.":"Ketuk hari untuk km, energi, dan pengisiannya.",
   "When the car is dark (no signal), missed km sync in one burst. Accurate (recommended) skips bursts that can't be dated to a day; Count all adds them to the day the car reconnects.":
@@ -968,8 +968,9 @@ function mqttStatusLine(st, cfg){
   if(!cfg || !cfg.enabled){ el.textContent=T('MQTT off'); return; }
   if(st && st.last_error){ el.className='err'; el.textContent=st.last_error; return; }
   if(st && st.connected){ el.className='ok';
+    const root=st.topic_root?(' · '+st.topic_root):'';
     const t=st.last_publish_ts?(' · pub '+new Date(st.last_publish_ts*1000).toLocaleTimeString()):'';
-    el.textContent=T('Connected')+t; return; }
+    el.textContent=T('Connected')+root+t; return; }
   el.textContent=T('Connecting…');
 }
 async function loadMqtt(){


### PR DESCRIPTION
## Summary
- Add an optional Home Assistant MQTT bridge (`tools/mqtt_bridge.py`): MQTT discovery, telemetry publish, and named remote-control commands (lock / climate / covers / find / stop charging).
- Wire Settings → MQTT UI, `/api/mqtt` + `/api/opcodes`, shared `tools/control_opcodes.json`, and surface body/climate fields on `/api/summary`.
- Add `requirements.txt` (including soft-dep `paho-mqtt`), update Docker/install install paths, and document setup in `docs/HOMEASSISTANT.md`.

## How it was tested
- [ ] Ran against my own car — model / year / region: (fill in)
- [ ] Ran in demo mode (`python server.py --demo`)
- [ ] Checked the dashboard in a browser (Settings → MQTT)
- [ ] Verified Home Assistant auto-discovery / entities when MQTT enabled

## Checklist
- [x] No `creds.json`, tokens, VIN, plate or location data in the diff
- [x] Docs updated (`README.md`, `README.id.md`, `creds.example.json`, `docs/HOMEASSISTANT.md`)
- [x] Only **stop charging** opcode is treated as confirmed; others remain best-effort / remappable

## Notes
- Soft-depends on `paho-mqtt`: dashboard works without it; bridge stays idle until the package is installed and MQTT is enabled.
- Independent of the Docker/GHCR PR — this only switches the image deps to `requirements.txt`; compose two-service layout is unchanged.